### PR TITLE
Use UPS product zmq not zeromq

### DIFF
--- a/upstools/create_ups_product.sh
+++ b/upstools/create_ups_product.sh
@@ -62,12 +62,12 @@ incdir fq_dir
 libdir fq_dir lib64
 
 product	    version
-zeromq	    v4_3_1
-czmq	    v4_2_0
+zmq	    v4_3_1
+czmq	    v4_2_0a
 protobuf    v3_5_2
 end_product_list
 
-qualifier	zeromq  czmq    protobuf
+qualifier	zmq    czmq    protobuf
 e15             e15	e15     e15     
 end_qualifier_list
 
@@ -102,9 +102,9 @@ setup ()
 }
 
 # We use get-directory-name from cetpkgsupport below
-setup -c cetpkgsupport
+[ -z "$CETPKGSUPPORT_DIR" ] && setup -c cetpkgsupport
 # We use build_table from cetbuildtools to make the table file from the product_deps file
-setup cetbuildtools v5_14_03
+[ -z "$CETBUILDTOOLS_DIR" ] && setup cetbuildtools v5_14_03
 
 # Sort the qualifiers in the same way as build_table does:
 # 'prof'/'debug' at the end, and the rest in alphabetical order

--- a/upstools/waf-configure-for-ups.sh
+++ b/upstools/waf-configure-for-ups.sh
@@ -7,9 +7,9 @@ if [ ! -f "$topdir/waf" ] ; then
     exit 1
 fi
 
-if [ -z "$ZEROMQ_VERSION" -o -z "$CZMQ_VERSION" -o -z "$PROTOBUF_VERSION" ] ; then
+if [ -z "$ZMQ_VERSION" -o -z "$CZMQ_VERSION" -o -z "$PROTOBUF_VERSION" ] ; then
     cat <<EOF
-This script assumes you have your UPS environment set up for the products 'zeromq', 'czmq' and 'protobuf'.
+This script assumes you have your UPS environment set up for the products 'zmq', 'czmq' and 'protobuf'.
 
 Maybe try:
 
@@ -30,7 +30,7 @@ echo "installing to $prefix"
 
 
 ./waf configure \
-      --with-libzmq-lib=$ZEROMQ_LIB --with-libzmq-include=$ZEROMQ_INC \
+      --with-libzmq-lib=$ZMQ_LIB --with-libzmq-include=$ZMQ_INC \
       --with-czmq-lib=$CZMQ_LIB --with-czmq-include=$CZMQ_INC \
       --with-protobuf=$PROTOBUF_FQ_DIR \
       --prefix=$prefix || exit 1


### PR DESCRIPTION
I got confused about the UPS product names on the np04daq machines. The ZeroMQ product I should be depending on is `zmq` not `zeromq`, so I've fixed that. `czmq` `v4_2_0a` depends on `zmq` not `zeromq` so I changed that as well. There's also a change to not setup the cet build packages if they're already set up